### PR TITLE
Allow large memory segments

### DIFF
--- a/docs/configuration/reference.rst
+++ b/docs/configuration/reference.rst
@@ -346,13 +346,13 @@ baseva <x>
 global-size <n>G | <n>M | <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-     Set the global memory size, memory shared across all router instances,
-     packet buffers, etc. If not set, defaults to 64M. The input value can be
-     set in GB, MB or bytes.
+    Set the global memory size, memory shared across all router instances,
+    packet buffers, etc. If not set, defaults to 64M. The input value can be
+    set in GB, MB or bytes. Values larger than 4G are supported.
 
 .. code-block:: console
 
-    global-size 2G
+    global-size 5G
 
 global-pvt-heap-size <n>M | size <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -377,12 +377,12 @@ api-pvt-heap-size <n>M | size <n>
 api-size <n>M | <n>G | <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-     Set the size of the API region. If not set, defaults to 16M. The input
-     value can be set in GB, MB or bytes.
+    Set the size of the API region. If not set, defaults to 16M. The input
+    value can be set in GB, MB or bytes. Values larger than 4G are supported.
 
 .. code-block:: console
 
-    api-size 64M
+    api-size 5G
 
 The socksvr Section
 -------------------

--- a/src/vpp/api/api.c
+++ b/src/vpp/api/api.c
@@ -297,12 +297,8 @@ api_segment_config (vlib_main_t * vm, unformat_input_t * input)
 	vl_set_memory_gid (gid);
       else if (unformat (input, "baseva %llx", &baseva))
 	vl_set_global_memory_baseva (baseva);
-      else if (unformat (input, "global-size %lldM", &size))
-	vl_set_global_memory_size (size * (1ULL << 20));
-      else if (unformat (input, "global-size %lldG", &size))
-	vl_set_global_memory_size (size * (1ULL << 30));
-      else if (unformat (input, "global-size %lld", &size))
-	vl_set_global_memory_size (size);
+      else if (unformat (input, "global-size %U", unformat_memory_size, &size))
+        vl_set_global_memory_size (size);
       else if (unformat (input, "global-pvt-heap-size %lldM", &pvt_heap_size))
 	vl_set_global_pvt_heap_size (pvt_heap_size * (1ULL << 20));
       else if (unformat (input, "global-pvt-heap-size size %lld",
@@ -313,12 +309,8 @@ api_segment_config (vlib_main_t * vm, unformat_input_t * input)
       else if (unformat (input, "api-pvt-heap-size size %lld",
 			 &pvt_heap_size))
 	vl_set_api_pvt_heap_size (pvt_heap_size);
-      else if (unformat (input, "api-size %lldM", &size))
-	vl_set_api_memory_size (size * (1ULL << 20));
-      else if (unformat (input, "api-size %lldG", &size))
-	vl_set_api_memory_size (size * (1ULL << 30));
-      else if (unformat (input, "api-size %lld", &size))
-	vl_set_api_memory_size (size);
+      else if (unformat (input, "api-size %U", unformat_memory_size, &size))
+        vl_set_api_memory_size (size);
       else if (unformat (input, "uid %s", &s))
 	{
 	  /* lookup the username */

--- a/src/vpp/conf/startup.conf
+++ b/src/vpp/conf/startup.conf
@@ -35,6 +35,9 @@ api-trace {
 
 api-segment {
   gid vpp
+  ## Example of allocating large shared memory regions
+  global-size 5G
+  api-size 5G
 }
 
 socksvr {
@@ -42,18 +45,18 @@ socksvr {
 }
 
 # memory {
-	## Set the main heap size, default is 1G
-	# main-heap-size 2G
+        ## Set the main heap size, default is 1G
+        # main-heap-size 2G
 
-	## Set the main heap page size. Default page size is OS default page
-	## which is in most cases 4K. if different page size is specified VPP
-	## will try to allocate main heap by using specified page size.
-	## special keyword 'default-hugepage' will use system default hugepage
-	## size
-	# main-heap-page-size 1G
-	## Set the default huge page size.
-	# default-hugepage-size 1G
-#}
+        ## Set the main heap page size. Default page size is OS default page
+        ## which is in most cases 4K. if different page size is specified VPP
+        ## will try to allocate main heap by using specified page size.
+        ## special keyword 'default-hugepage' will use system default hugepage
+        ## size
+        # main-heap-page-size 1G
+        ## Set the default huge page size.
+        # default-hugepage-size 1G
+# }
 
 cpu {
 	## In the VPP there is one main thread and optionally the user can create worker(s)


### PR DESCRIPTION
## Summary
- parse `global-size` and `api-size` using `unformat_memory_size`
- show how to allocate >4G in `startup.conf`
- document ability to set sizes over 4G
- fix startup configuration example

## Testing
- `make checkstyle` *(fails: ModuleNotFoundError: No module named 'yaml')*
