### PR TITLE
Allow large memory segments

### DIFF
--- a/docs/configuration/reference.rst
+++ b/docs/configuration/reference.rst
@@ -346,29 +346,33 @@ baseva <x>
 global-size <n>G | <n>M | <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-     Set the global memory size, memory shared across all router instances,
-     packet buffers, etc. If not set, defaults to 64M. The input value can be
-     set in GB, MB or bytes.
+    Set the global memory size, memory shared across all router instances,
+    packet buffers, etc. If not set, defaults to 64M. The input value can be
+    set in GB, MB or bytes. Values larger than 4G are supported.
 
 .. code-block:: console
 
-    global-size 2G
+    global-size 5G
 
 global-pvt-heap-size <n>M | size <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-     Set the size of the global VM private mheap. If not set, defaults to 128k.
-     The input value can be set in MB or bytes.
+    Set the size of the global VM private mheap. If not set, defaults to 128k.
+    The input value can be set in MB or bytes. When ``global-size`` is large
+    this heap must also grow. VPP automatically chooses a suitable size if it
+    is left unset.
 
 .. code-block:: console
 
-    global-pvt-heap-size size 262144
+    global-pvt-heap-size 1M
 
 api-pvt-heap-size <n>M | size <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-     Set the size of the api private mheap. If not set, defaults to 128k.
-     The input value can be set in MB or bytes.
+    Set the size of the api private mheap. If not set, defaults to 128k.
+    The input value can be set in MB or bytes. If ``api-size`` is large the
+    heap must be increased. VPP will compute a reasonable value when this is
+    not specified.
 
 .. code-block:: console
 
@@ -377,12 +381,12 @@ api-pvt-heap-size <n>M | size <n>
 api-size <n>M | <n>G | <n>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-     Set the size of the API region. If not set, defaults to 16M. The input
-     value can be set in GB, MB or bytes.
+    Set the size of the API region. If not set, defaults to 16M. The input
+    value can be set in GB, MB or bytes. Values larger than 4G are supported.
 
 .. code-block:: console
 
-    api-size 64M
+    api-size 5G
 
 The socksvr Section
 -------------------

--- a/src/vlibapi/memory_shared.c
+++ b/src/vlibapi/memory_shared.c
@@ -36,6 +36,12 @@
 #include <vlibmemory/memory_api.h>
 #include <vlibmemory/vl_memory_msg_enum.h>
 #include <vlibapi/api_common.h>
+#include <svm/svm.h>
+#include <svm/svm_common.h>
+
+#define PVT_HEAP_SIZE_FOR_REGION(sz) \
+  (((sz) >> 15) < SVM_PVT_MHEAP_SIZE ? \
+   SVM_PVT_MHEAP_SIZE : (((sz) >> 15) + MMAP_PAGESIZE - 1) & ~(MMAP_PAGESIZE - 1))
 
 #define vl_typedefs
 #include <vlibmemory/vl_memory_api_h.h>
@@ -379,6 +385,8 @@ vl_set_global_memory_size (u64 size)
   api_main_t *am = vlibapi_get_main ();
 
   am->global_size = size;
+  if (am->global_pvt_heap_size == 0)
+    am->global_pvt_heap_size = PVT_HEAP_SIZE_FOR_REGION (size);
 }
 
 void
@@ -387,6 +395,8 @@ vl_set_api_memory_size (u64 size)
   api_main_t *am = vlibapi_get_main ();
 
   am->api_size = size;
+  if (am->api_pvt_heap_size == 0)
+    am->api_pvt_heap_size = PVT_HEAP_SIZE_FOR_REGION (size);
 }
 
 void

--- a/src/vlibmemory/memory_api.c
+++ b/src/vlibmemory/memory_api.c
@@ -20,6 +20,12 @@
 #include <vlibapi/api.h>
 #include <vlibmemory/api.h>
 #include <vlibmemory/memory_api.h>
+#include <svm/svm.h>
+#include <svm/svm_common.h>
+
+#define PVT_HEAP_SIZE_FOR_REGION(sz) \
+  (((sz) >> 15) < SVM_PVT_MHEAP_SIZE ? \
+   SVM_PVT_MHEAP_SIZE : (((sz) >> 15) + MMAP_PAGESIZE - 1) & ~(MMAP_PAGESIZE - 1))
 
 #include <vlibmemory/vl_memory_msg_enum.h>	/* enumerate all vlib messages */
 
@@ -1176,8 +1182,8 @@ vlibmemory_init (vlib_main_t * vm)
   a->uid = am->api_uid;
   a->gid = am->api_gid;
   a->pvt_heap_size =
-    (am->global_pvt_heap_size !=
-     0) ? am->global_pvt_heap_size : SVM_PVT_MHEAP_SIZE;
+    (am->global_pvt_heap_size != 0) ?
+    am->global_pvt_heap_size : PVT_HEAP_SIZE_FOR_REGION (a->size);
 
   svm_region_init_args (a);
 

--- a/src/vpp/api/api.c
+++ b/src/vpp/api/api.c
@@ -297,12 +297,8 @@ api_segment_config (vlib_main_t * vm, unformat_input_t * input)
 	vl_set_memory_gid (gid);
       else if (unformat (input, "baseva %llx", &baseva))
 	vl_set_global_memory_baseva (baseva);
-      else if (unformat (input, "global-size %lldM", &size))
-	vl_set_global_memory_size (size * (1ULL << 20));
-      else if (unformat (input, "global-size %lldG", &size))
-	vl_set_global_memory_size (size * (1ULL << 30));
-      else if (unformat (input, "global-size %lld", &size))
-	vl_set_global_memory_size (size);
+      else if (unformat (input, "global-size %U", unformat_memory_size, &size))
+        vl_set_global_memory_size (size);
       else if (unformat (input, "global-pvt-heap-size %lldM", &pvt_heap_size))
 	vl_set_global_pvt_heap_size (pvt_heap_size * (1ULL << 20));
       else if (unformat (input, "global-pvt-heap-size size %lld",
@@ -313,12 +309,8 @@ api_segment_config (vlib_main_t * vm, unformat_input_t * input)
       else if (unformat (input, "api-pvt-heap-size size %lld",
 			 &pvt_heap_size))
 	vl_set_api_pvt_heap_size (pvt_heap_size);
-      else if (unformat (input, "api-size %lldM", &size))
-	vl_set_api_memory_size (size * (1ULL << 20));
-      else if (unformat (input, "api-size %lldG", &size))
-	vl_set_api_memory_size (size * (1ULL << 30));
-      else if (unformat (input, "api-size %lld", &size))
-	vl_set_api_memory_size (size);
+      else if (unformat (input, "api-size %U", unformat_memory_size, &size))
+        vl_set_api_memory_size (size);
       else if (unformat (input, "uid %s", &s))
 	{
 	  /* lookup the username */

--- a/src/vpp/conf/startup.conf
+++ b/src/vpp/conf/startup.conf
@@ -42,18 +42,24 @@ socksvr {
 }
 
 # memory {
-	## Set the main heap size, default is 1G
-	# main-heap-size 2G
+        ## Set the main heap size, default is 1G
+        # main-heap-size 2G
 
-	## Set the main heap page size. Default page size is OS default page
-	## which is in most cases 4K. if different page size is specified VPP
-	## will try to allocate main heap by using specified page size.
-	## special keyword 'default-hugepage' will use system default hugepage
-	## size
-	# main-heap-page-size 1G
-	## Set the default huge page size.
-	# default-hugepage-size 1G
-#}
+        ## Example of allocating large shared memory regions
+        # global-size 5G
+        # api-size 5G
+        # global-pvt-heap-size 1M
+        # api-pvt-heap-size 1M
+
+        ## Set the main heap page size. Default page size is OS default page
+        ## which is in most cases 4K. if different page size is specified VPP
+        ## will try to allocate main heap by using specified page size.
+        ## special keyword 'default-hugepage' will use system default hugepage
+        ## size
+        # main-heap-page-size 1G
+        ## Set the default huge page size.
+        # default-hugepage-size 1G
+# }
 
 cpu {
 	## In the VPP there is one main thread and optionally the user can create worker(s)


### PR DESCRIPTION
## Summary
- parse `global-size` and `api-size` using `unformat_memory_size`
- autoscale private heap sizes when memory segments are large
- document heap sizing behavior and give config example

## Testing
- `make checkstyle` *(fails: ModuleNotFoundError: No module named 'yaml')*
